### PR TITLE
Update pyproject.toml - Allow newer versions of pywerview

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pyasn1-modules = "^0.3.0"
 pylnk3 = "^0.4.2"
 pypsrp = "^0.8.1"
 pypykatz = "^0.6.8"
-pywerview = "^0.3.3" # pywerview 5 requires libkrb5-dev installed which is not default on kali (as of 9/23)
+pywerview = ">=0.3.3"
 python-dateutil = ">=2.8.2"
 python-libnmap = "^0.7.3"
 requests = ">=2.27.1"


### PR DESCRIPTION
The pywerview version requirement was restricting it to a very old version. The problem that required this no longer seems to be present, so the version-spec has been opened up to allow newer versions of pywerview.